### PR TITLE
tracking(ui): initialize Movement Speed from runtime step_delay at st…

### DIFF
--- a/laserturret/stepper_controller.py
+++ b/laserturret/stepper_controller.py
@@ -1047,6 +1047,7 @@ class StepperController:
                 'x_steps_per_pixel': self.calibration.x_steps_per_pixel,
                 'y_steps_per_pixel': self.calibration.y_steps_per_pixel,
                 'dead_zone_pixels': self.calibration.dead_zone_pixels,
+                'step_delay': self.calibration.step_delay,
                 'is_calibrated': self.calibration.is_calibrated,
                 'calibration_timestamp': self.calibration.calibration_timestamp
             },

--- a/templates/index.html
+++ b/templates/index.html
@@ -3155,6 +3155,16 @@
                                     document.getElementById('camera-dead-zone').value = 
                                         controller.calibration.dead_zone_pixels;
                                     updateCameraDeadZoneValue();
+
+                                    if (typeof controller.calibration.step_delay === 'number') {
+                                        const sliderEl = document.getElementById('camera-step-delay');
+                                        if (sliderEl) {
+                                            let sliderVal = 0.0055 - controller.calibration.step_delay;
+                                            sliderVal = Math.max(0.0005, Math.min(0.005, sliderVal));
+                                            sliderEl.value = sliderVal;
+                                            updateCameraStepDelayValue();
+                                        }
+                                    }
                                     
                                     // Mark as initialized so we don't overwrite user changes
                                     calibrationSlidersInitialized = true;


### PR DESCRIPTION
…artup

backend: expose calibration.step_delay in /tracking/camera/status (StepperController.get_status)

ui: initialize camera-step-delay slider + label from backend on first load

Fixes mismatch where UI speed didn’t reflect actual runtime value until Apply.