### PR TITLE
Fixes video duration calculation type error

### DIFF
--- a/app.py
+++ b/app.py
@@ -2627,7 +2627,7 @@ def get_consolidated_status():
         status['recording'] = {
             'is_recording': is_recording,
             'filename': recording_filename,
-            'duration': (time.time() - recording_start_time) if is_recording and recording_start_time else 0
+            'duration': (datetime.now() - recording_start_time).total_seconds() if is_recording and recording_start_time else 0
         }
     
     # Pattern status


### PR DESCRIPTION
Resolves issue #55

Fixed type mismatch in get_consolidated_status() where recording_start_time (datetime) was subtracted from time.time() (float). Changed to use datetime.now() - recording_start_time for consistency with other endpoints.