### PR TITLE
Fix auto-fire: Add distance-based gating and mock fire indicator

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -445,6 +445,14 @@
                             </div>
                         </div>
 
+                        <div class="slider-control">
+                            <label>🎯 Auto-Fire Distance (pixels)</label>
+                            <div class="slider-wrapper">
+                                <input type="range" id="auto-fire-distance" min="10" max="200" value="50" step="5" oninput="updateAutoFireDistanceValue()">
+                                <span id="auto-fire-distance-value" class="slider-value">50px</span>
+                            </div>
+                        </div>
+
                         <button class="btn-primary" onclick="applyLaserSettings()">Apply Fire Settings</button>
                     </div>
 
@@ -1503,12 +1511,18 @@
             document.getElementById('laser-power-value').textContent = value + '%';
         }
 
+        function updateAutoFireDistanceValue() {
+            const value = parseInt(document.getElementById('auto-fire-distance').value);
+            document.getElementById('auto-fire-distance-value').textContent = value + 'px';
+        }
+
         function applyLaserSettings() {
             const pulseDuration = parseFloat(document.getElementById('pulse-duration').value) / 1000;
             const burstCount = parseInt(document.getElementById('burst-count').value);
             const burstDelay = parseFloat(document.getElementById('burst-delay').value) / 1000;
             const cooldown = parseFloat(document.getElementById('laser-cooldown').value);
             const power = parseInt(document.getElementById('laser-power').value);
+            const autoFireDistance = parseInt(document.getElementById('auto-fire-distance').value);
             
             fetch('/laser/settings', {
                 method: 'POST',
@@ -1518,7 +1532,8 @@
                     burst_count: burstCount,
                     burst_delay: burstDelay,
                     cooldown: cooldown,
-                    power: power
+                    power: power,
+                    auto_fire_distance_threshold: autoFireDistance
                 })
             })
             .then(response => response.json())
@@ -2398,11 +2413,15 @@
                         if (data.power !== undefined) {
                             document.getElementById('laser-power').value = data.power;
                         }
+                        if (data.auto_fire_distance_threshold !== undefined) {
+                            document.getElementById('auto-fire-distance').value = data.auto_fire_distance_threshold;
+                        }
                         updatePulseDurationValue();
                         updateBurstCountValue();
                         updateBurstDelayValue();
                         updateLaserCooldownValue();
                         updateLaserPowerValue();
+                        updateAutoFireDistanceValue();
                     }
                 })
                 .catch(error => console.error('Error syncing laser sliders:', error));


### PR DESCRIPTION
## Summary

This PR fixes the auto-fire functionality by adding two critical improvements:

### 1. Distance-Based Auto-Fire Gating
Auto-fire now only triggers when the crosshair is within a configurable distance of the target, ensuring the laser doesn't fire until tracking has properly aligned on the target.

**Changes:**
- Added uto_fire_distance_threshold variable (default 50px, configurable 10-200px)
- Modified check_auto_fire() to calculate Euclidean distance between crosshair and target position
- Works with both object detection and motion tracking modes
- Supports both 'crosshair' and 'camera' tracking modes
- Added REST API support in /laser/settings (POST) and /laser/status (GET)
- Added UI slider control in laser settings panel with live value display

### 2. Mock Fire Visual Indicator Fix
The mock fire visual indicator (red crosshair and circle) now properly displays during auto-fire events.

**Root Cause:** Race condition - auto-fire thread was setting mock_fire_active without proper synchronization while the rendering thread read it with a lock.

**Fix:** Added proper thread synchronization using laser_lock for all mock_fire_active, ire_count, and last_fire_time accesses.

## Testing
- [x] Manual fire works in mock mode
- [x] Auto-fire triggers visual indicator in mock mode
- [x] Distance threshold configurable via UI
- [x] Works with object detection tracking
- [x] Works with motion detection tracking
- [x] Thread-safe concurrent access

Fixes #59