### PR TITLE
Use start position for absolute center moves in calibration

### DIFF
--- a/laserturret/stepper_controller.py
+++ b/laserturret/stepper_controller.py
@@ -854,6 +854,10 @@ class StepperController:
             try:
                 results = {}
                 
+                # Track starting positions before calibration
+                x_start_position = self.calibration.x_position
+                y_start_position = self.calibration.y_position
+                
                 # Calibrate X axis
                 report('info', 'Calibrating X axis - finding limits')
                 x_range = self._find_axis_limits('x', report)
@@ -864,15 +868,19 @@ class StepperController:
                 y_range = self._find_axis_limits('y', report)
                 results['y_range'] = y_range
                 
-                # Calculate center and move there
-                x_center = (x_range['min'] + x_range['max']) // 2
-                y_center = (y_range['min'] + y_range['max']) // 2
+                # Calculate center positions (offsets from where each axis started)
+                x_center_offset = (x_range['min'] + x_range['max']) // 2
+                y_center_offset = (y_range['min'] + y_range['max']) // 2
                 
-                report('info', f'Moving to center position: X={x_center}, Y={y_center}')
+                # Convert to absolute positions
+                x_center_absolute = x_start_position + x_center_offset
+                y_center_absolute = y_start_position + y_center_offset
+                
+                report('info', f'Moving to center position: X={x_center_absolute}, Y={y_center_absolute}')
                 
                 # Move to center (bypass limits since we're still calibrating) using default step delay
-                self.step('x', x_center - self.calibration.x_position, bypass_limits=True)
-                self.step('y', y_center - self.calibration.y_position, bypass_limits=True)
+                self.step('x', x_center_absolute - self.calibration.x_position, bypass_limits=True)
+                self.step('y', y_center_absolute - self.calibration.y_position, bypass_limits=True)
                 
                 # Set this as home (0, 0)
                 self.calibration.x_position = 0


### PR DESCRIPTION
Addresses #47.

- **What**
  - Track starting axis positions before calibration.
  - Compute center as an absolute coordinate by offsetting the relative center with the pre-calibration start position.
  - Use the resulting absolute target delta for the move to center, bypassing limits during the centering step only.
  - Reset the home reference after centering.
  - Update logs to reflect absolute coordinates for clarity.

- **Why**
  - Improves centering accuracy when calibration begins from a non-zero origin.

- **Testing**
  - Start from a non-zero origin and run `StepperController.auto_calibrate()` via the control panel (`python app.py`). Verify the center move lands at the expected absolute coordinates.
  - Optional: run `python scripts/test_with_mock_hardware.py` for a hardware-free sanity check.

- **Notes**
  - No UI changes.
  - Review the temporary limit bypass during the centering move for safety.