### PR TITLE
Relocate tracking tab quick actions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -279,6 +279,18 @@
                 <!-- Camera Tracking Tab -->
                 <div id="tracking-tab" class="tab-content">
                     <div class="control-group">
+                        <h3>🚀 Quick Actions</h3>
+                        <div style="display: flex; flex-wrap: wrap; gap: 10px;">
+                            <button class="btn-success" onclick="runAutoCalibration()" style="flex: 1 1 200px;">
+                                🤖 Auto-Calibrate & Home
+                            </button>
+                            <button class="btn-primary" id="home-camera-btn" onclick="homeCameraPosition()" style="flex: 1 1 200px;">
+                                🏠 Home Camera to Center
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="control-group">
                         <h3>📹 Tracking Mode</h3>
                         <div class="toggle-switch">
                             <label class="switch">
@@ -295,7 +307,7 @@
                     <!-- Calibration required warning should always be present (toggled by JS) -->
                     <div id="calibration-required-warning" style="display: none; margin-bottom: 20px; padding: 15px; background: #f8d7da; border: 2px solid #f5c6cb; border-radius: 8px; color: #721c24;">
                         <h3 style="margin-bottom: 10px;">⚠️ Calibration Required</h3>
-                        <p style="margin-bottom: 10px;">Camera tracking must be calibrated before use. Please run the Auto-Calibration sequence below.</p>
+                        <p style="margin-bottom: 10px;">Camera tracking must be calibrated before use. Please run the Auto-Calibration sequence above.</p>
                         <p style="font-size: 12px; opacity: 0.9;">Calibration data will be retained as long as motors remain enabled.</p>
                     </div>
 
@@ -318,10 +330,6 @@
                             </label>
                             <span class="toggle-label">Re-center camera slowly on target loss</span>
                         </div>
-
-                        <button class="btn-primary" id="home-camera-btn" onclick="homeCameraPosition()" style="margin-top: 10px;">
-                            🏠 Home Camera to Center
-                        </button>
 
                         <div style="margin-top: 15px; padding: 12px; background: #fff3cd; border-radius: 6px; font-size: 13px; color: #856404;">
                             <strong>⚠️ Important:</strong> Ensure stepper motors are properly connected before enabling camera tracking.
@@ -379,12 +387,6 @@
                         <button class="btn-primary" onclick="applyPID()">Apply PID</button>
                     </div>
 
-                    <div class="control-group" style="background: #eef2ff; border: 1px dashed #c7d2fe; color: #4338ca;">
-                        <h3>🎯 Manual Position Control</h3>
-                        <p style="font-size: 13px; color: #4338ca;">
-                            Manual aim controls now live on top of the live video so you can make adjustments while watching the feed. Use the arrow pad overlay to nudge the turret, tweak the step size slider, or jump home without losing sight of the target.
-                        </p>
-                    </div>
                     </div> <!-- /#camera-tracking-controls -->
 
                     <div class="control-group">
@@ -392,10 +394,6 @@
                         <p style="color: #666; font-size: 13px; margin-bottom: 15px;">
                             Automatically find limits and set home position, or manually calibrate steps-per-pixel
                         </p>
-
-                        <button class="btn-success" onclick="runAutoCalibration()" style="margin-bottom: 15px;">
-                            🤖 Auto-Calibrate & Home
-                        </button>
 
                         <div style="margin-bottom: 15px; padding: 10px; background: #e3f2fd; border-radius: 6px; font-size: 12px; color: #1565c0;">
                             <strong>Auto-Calibration:</strong> Finds movement limits in all directions, moves to center, and sets home position. May take several minutes.


### PR DESCRIPTION
## Summary
- add a quick actions block to the tracking tab so auto-calibrate and home camera controls live at the top
- update calibration messaging and remove the redundant manual position control container

## Testing
- python app.py *(fails: ModuleNotFoundError: No module named 'picamera2')*


------
https://chatgpt.com/codex/tasks/task_e_68ef2d669ce0832eb2bbcda9a2f6a7fc