### PR TITLE
Restore BGR conversion for recorded frames

### DIFF
--- a/app.py
+++ b/app.py
@@ -1233,7 +1233,8 @@ def generate_frames():
             with recording_lock:
                 if is_recording and video_writer is not None:
                     try:
-                        video_writer.write(frame_rgb)
+                        frame_bgr = cv2.cvtColor(frame_rgb, cv2.COLOR_RGB2BGR)
+                        video_writer.write(frame_bgr)
                         recording_frames_written += 1
                     except Exception as e:
                         print(f"Error writing video frame: {e}")


### PR DESCRIPTION
## Summary
- convert recorded frames back to BGR before handing them to OpenCV's VideoWriter
- preserve correct channel ordering for saved recordings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4637d74b0832eb1b41ea32c3a74ab