### PR TITLE
Enhances wide-screen layout with fixed side panel

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -33,8 +33,25 @@
             flex-direction: column;
             gap: 20px;
             align-items: stretch;
-            max-width: 1400px;
+            max-width: 1800px;
             margin: 0 auto;
+        }
+
+        @media (min-width: 1200px) {
+            .control-layout {
+                flex-direction: row;
+                align-items: flex-start;
+            }
+
+            .video-section {
+                flex: 1 1 auto;
+                min-width: 0;
+            }
+
+            .controls-panel {
+                flex: 0 0 420px;
+                width: 420px;
+            }
         }
 
         .video-section {

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -33,7 +33,7 @@
             flex-direction: column;
             gap: 20px;
             align-items: stretch;
-            max-width: 1800px;
+            max-width: 2400px;
             margin: 0 auto;
         }
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -33,7 +33,7 @@
             flex-direction: column;
             gap: 20px;
             align-items: stretch;
-            max-width: 2400px;
+            max-width: 95%;
             margin: 0 auto;
         }
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -49,8 +49,8 @@
             }
 
             .controls-panel {
-                flex: 0 0 500px;
-                width: 500px;
+                flex: 0 0 650px;
+                width: 650px;
             }
         }
 

--- a/static/css/index.css
+++ b/static/css/index.css
@@ -49,8 +49,8 @@
             }
 
             .controls-panel {
-                flex: 0 0 420px;
-                width: 420px;
+                flex: 0 0 500px;
+                width: 500px;
             }
         }
 


### PR DESCRIPTION
Increases maximum content width to 1800px to better utilize large displays.
Introduces a breakpoint at 1200px to switch from vertical to horizontal layout:
- control area becomes a row with a fixed-width panel for stable controls
- video area becomes flexible, preserving space and preventing overflow
Keeps small-screen behavior intact while improving desktop usability and balance.