### PR TITLE
feat: add target priority selector to overlay controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -1159,6 +1159,7 @@ def create_crosshair(frame, color=(0, 255, 0), thickness=3, opacity=0.5):
                 obj_text = f"Detect: {detection_method.upper()} ({len(detected_objects)})"
             if object_auto_track:
                 obj_text += " [TRACK]"
+            obj_text += f" | Priority: {target_priority.upper()}"
             texts.append(obj_text)
     
     # Add motion detection status
@@ -1943,7 +1944,7 @@ def toggle_object_auto_track():
 @app.route('/object_detection/settings', methods=['POST'])
 def update_object_settings():
     """Update object detection settings"""
-    global detection_mode, target_priority
+    global detection_mode, target_priority, object_track_smooth_center, object_last_switch_time
     
     try:
         data = request.get_json()
@@ -1952,7 +1953,11 @@ def update_object_settings():
                 detection_mode = data['mode']
             
             if 'priority' in data:
-                target_priority = data['priority']
+                new_priority = data['priority']
+                if new_priority != target_priority:
+                    object_track_smooth_center = None
+                    object_last_switch_time = 0.0
+                target_priority = new_priority
         
         return jsonify({
             'status': 'success',

--- a/templates/index.html
+++ b/templates/index.html
@@ -102,6 +102,15 @@
                             <button id="overlay-objects-track" class="overlay-toggle-chip" onclick="toggleObjectAutoTrackFromOverlay()">Auto-Track</button>
                         </div>
                         <div class="overlay-slider">
+                            <label for="overlay-target-priority">Target Priority</label>
+                            <select id="overlay-target-priority" onchange="applyOverlayTargetPriority()">
+                                <option value="largest">Largest Object</option>
+                                <option value="closest">Closest Object</option>
+                                <option value="leftmost">Leftmost Object</option>
+                                <option value="rightmost">Rightmost Object</option>
+                            </select>
+                        </div>
+                        <div class="overlay-slider">
                             <label for="overlay-object-confidence" style="display: flex; justify-content: space-between; align-items: center;">
                                 <span>Confidence Threshold</span>
                                 <span id="overlay-object-confidence-value" class="overlay-slider-value">0.50</span>
@@ -1120,7 +1129,6 @@
             if (targetContent) {
                 targetContent.classList.add('active');
             }
-
             const targetButton = buttonEl || document.querySelector(`.tab[data-tab="${tabName}"]`);
             if (targetButton) {
                 targetButton.classList.add('active');
@@ -1134,6 +1142,14 @@
                 // Refresh object status to show appropriate panel for selected method
                 updateObjectStatus();
             }
+        }
+
+        function applyOverlayTargetPriority() {
+            const overlaySelect = document.getElementById('overlay-target-priority');
+            if (!overlaySelect) return;
+            const mainSelect = document.getElementById('target-priority');
+            if (mainSelect) mainSelect.value = overlaySelect.value;
+            applyObjectSettings();
         }
 
         // Crosshair positioning with camera movement support
@@ -2333,6 +2349,8 @@
                         document.getElementById('object-enabled').checked = data.enabled;
                         document.getElementById('object-auto-track-enabled').checked = data.auto_track;
                         document.getElementById('target-priority').value = data.priority;
+                        const overlayPriority = document.getElementById('overlay-target-priority');
+                        if (overlayPriority) overlayPriority.value = data.priority;
 
                         const detectBtn = document.getElementById('overlay-objects-detect');
                         if (detectBtn) detectBtn.classList.toggle('active', !!data.enabled);


### PR DESCRIPTION
- Added dropdown menu in overlay for selecting object targeting priority (largest, closest, leftmost, rightmost)
- Synchronized overlay priority selector with main settings panel to maintain consistency
- Added applyOverlayTargetPriority function to handle priority changes from overlay
- Updated object settings handler to reflect priority changes in both overlay and main controls